### PR TITLE
Clean up build utils

### DIFF
--- a/dist/css/color/dark.css
+++ b/dist/css/color/dark.css
@@ -3,6 +3,9 @@
  */
 
 :root {
+  --tmp-color-brand-default: #e95420;
+  --tmp-color-brand-hover: #da4816;
+  --tmp-color-brand-active: #cc4414;
   --tmp-color-positive: #62a36c;
   --tmp-color-negative: #d17b85;
   --tmp-color-information: #5ea6ed;
@@ -34,12 +37,6 @@
   --tmp-color-background-caution-active: rgba(255, 115, 0, 0.36);
   --tmp-color-background-input: #2f2f2f;
   --tmp-color-background-overlay: rgba(17, 17, 17, 0.85);
-  --tmp-color-background-button-positive-default: #008013;
-  --tmp-color-background-button-positive-hover: #00670f;
-  --tmp-color-background-button-positive-active: #00570d;
-  --tmp-color-background-button-negative-default: #a11223;
-  --tmp-color-background-button-negative-hover: #8a0f1e;
-  --tmp-color-background-button-negative-active: #7c0e1b;
   --tmp-color-border-default: rgba(255, 255, 255, 0.2);
   --tmp-color-border-highlight: #ffffff;
   --tmp-color-border-high-contrast: #939393;
@@ -48,12 +45,6 @@
   --tmp-color-icon-status-shade-1: #f7f7f7;
   --tmp-color-icon-status-shade-2: #d9d9d9;
   --tmp-color-icon-status-queued: #808080;
-  --tmp-color-icon-canonical-logo: #ffffff;
-  --tmp-color-icon-button-brand: #ffffff;
-  --tmp-color-icon-button-default: #000000;
-  --tmp-color-icon-button-base: #000000;
-  --tmp-color-icon-button-positive: #ffffff;
-  --tmp-color-icon-button-negative: #ffffff;
   --tmp-color-fill-positive-default: #008013;
   --tmp-color-fill-positive-hover: #00670f;
   --tmp-color-fill-positive-active: #00570d;

--- a/dist/css/color/light.css
+++ b/dist/css/color/light.css
@@ -3,6 +3,9 @@
  */
 
 :root {
+  --tmp-color-brand-default: #e95420;
+  --tmp-color-brand-hover: #da4816;
+  --tmp-color-brand-active: #cc4414;
   --tmp-color-positive: #0e8420;
   --tmp-color-negative: #c7162b;
   --tmp-color-information: #24598f;
@@ -34,12 +37,6 @@
   --tmp-color-background-caution-active: rgba(199, 90, 0, 0.18);
   --tmp-color-background-input: #f5f5f5;
   --tmp-color-background-overlay: rgba(17, 17, 17, 0.85);
-  --tmp-color-background-button-positive-default: #0e8420;
-  --tmp-color-background-button-positive-hover: #0c6d1a;
-  --tmp-color-background-button-positive-active: #0a5f17;
-  --tmp-color-background-button-negative-default: #c7162b;
-  --tmp-color-background-button-negative-hover: #b01326;
-  --tmp-color-background-button-negative-active: #a21223;
   --tmp-color-border-default: rgba(0, 0, 0, 0.2);
   --tmp-color-border-highlight: #000000;
   --tmp-color-border-high-contrast: #707070;
@@ -48,12 +45,6 @@
   --tmp-color-icon-status-shade-1: #f7f7f7;
   --tmp-color-icon-status-shade-2: #d9d9d9;
   --tmp-color-icon-status-queued: #808080;
-  --tmp-color-icon-canonical-logo: #ffffff;
-  --tmp-color-icon-button-brand: #ffffff;
-  --tmp-color-icon-button-default: #000000;
-  --tmp-color-icon-button-base: #000000;
-  --tmp-color-icon-button-positive: #ffffff;
-  --tmp-color-icon-button-negative: #ffffff;
   --tmp-color-fill-positive-hover: #0c6d1a;
   --tmp-color-fill-positive-active: #0a5f17;
   --tmp-color-fill-negative-hover: #b01326;

--- a/dist/css/color/system.css
+++ b/dist/css/color/system.css
@@ -2,86 +2,11 @@
  * Do not edit directly, this file was auto-generated.
  */
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --tmp-color-positive: #62a36c;
-    --tmp-color-negative: #d17b85;
-    --tmp-color-information: #5ea6ed;
-    --tmp-color-caution: #c48831;
-    --tmp-color-text-default: #ffffff;
-    --tmp-color-text-muted: rgba(255, 255, 255, 0.6);
-    --tmp-color-text-inactive: rgba(255, 255, 255, 0.75);
-    --tmp-color-text-reversed: #000000;
-    --tmp-color-text-link-default: #6699cc;
-    --tmp-color-text-link-visited: #a679d2;
-    --tmp-color-background-default: #262626;
-    --tmp-color-background-hover: #313131;
-    --tmp-color-background-active: #373737;
-    --tmp-color-background-alt: #202020;
-    --tmp-color-background-neutral-default: rgba(255, 255, 255, 0.15);
-    --tmp-color-background-neutral-hover: rgba(255, 255, 255, 0.2);
-    --tmp-color-background-neutral-active: rgba(255, 255, 255, 0.25);
-    --tmp-color-background-positive-default: rgba(10, 189, 37, 0.2);
-    --tmp-color-background-positive-hover: rgba(0, 199, 30, 0.3);
-    --tmp-color-background-positive-active: rgba(0, 199, 30, 0.36);
-    --tmp-color-background-negative-default: rgba(255, 102, 120, 0.2);
-    --tmp-color-background-negative-hover: rgba(255, 102, 120, 0.3);
-    --tmp-color-background-negative-active: rgba(255, 102, 120, 0.36);
-    --tmp-color-background-information-default: rgba(0, 137, 255, 0.2);
-    --tmp-color-background-information-hover: rgba(0, 137, 255, 0.3);
-    --tmp-color-background-information-active: rgba(0, 137, 255, 0.36);
-    --tmp-color-background-caution-default: rgba(255, 115, 0, 0.2);
-    --tmp-color-background-caution-hover: rgba(255, 143, 51, 0.3);
-    --tmp-color-background-caution-active: rgba(255, 115, 0, 0.36);
-    --tmp-color-background-input: #2f2f2f;
-    --tmp-color-background-overlay: rgba(17, 17, 17, 0.85);
-    --tmp-color-background-button-positive-default: #008013;
-    --tmp-color-background-button-positive-hover: #00670f;
-    --tmp-color-background-button-positive-active: #00570d;
-    --tmp-color-background-button-negative-default: #a11223;
-    --tmp-color-background-button-negative-hover: #8a0f1e;
-    --tmp-color-background-button-negative-active: #7c0e1b;
-    --tmp-color-border-default: rgba(255, 255, 255, 0.2);
-    --tmp-color-border-highlight: #ffffff;
-    --tmp-color-border-high-contrast: #939393;
-    --tmp-color-border-low-contrast: rgba(255, 255, 255, 0.1);
-    --tmp-color-border-neutral: #a6a6a6;
-    --tmp-color-icon-status-shade-1: #f7f7f7;
-    --tmp-color-icon-status-shade-2: #d9d9d9;
-    --tmp-color-icon-status-queued: #808080;
-    --tmp-color-icon-canonical-logo: #ffffff;
-    --tmp-color-icon-button-brand: #ffffff;
-    --tmp-color-icon-button-default: #000000;
-    --tmp-color-icon-button-base: #000000;
-    --tmp-color-icon-button-positive: #ffffff;
-    --tmp-color-icon-button-negative: #ffffff;
-    --tmp-color-fill-positive-default: #008013;
-    --tmp-color-fill-positive-hover: #00670f;
-    --tmp-color-fill-positive-active: #00570d;
-    --tmp-color-fill-negative-default: #a11223;
-    --tmp-color-fill-negative-hover: #8a0f1e;
-    --tmp-color-fill-negative-active: #7c0e1b;
-    --tmp-color-border-positive: var(--tmp-color-positive);
-    --tmp-color-border-negative: var(--tmp-color-negative);
-    --tmp-color-border-information: var(--tmp-color-information);
-    --tmp-color-border-caution: var(--tmp-color-caution);
-    --tmp-color-icon-default: var(--tmp-color-text-default);
-    --tmp-color-icon-muted: var(--tmp-color-text-muted);
-    --tmp-color-icon-positive: var(--tmp-color-positive);
-    --tmp-color-icon-negative: var(--tmp-color-negative);
-    --tmp-color-icon-information: var(--tmp-color-information);
-    --tmp-color-icon-caution: var(--tmp-color-caution);
-    --tmp-color-icon-link: var(--tmp-color-text-link-default);
-  }
-}
-
-
-/**
- * Do not edit directly, this file was auto-generated.
- */
-
 @media (prefers-color-scheme: light) {
   :root {
+    --tmp-color-brand-default: #e95420;
+    --tmp-color-brand-hover: #da4816;
+    --tmp-color-brand-active: #cc4414;
     --tmp-color-positive: #0e8420;
     --tmp-color-negative: #c7162b;
     --tmp-color-information: #24598f;
@@ -113,12 +38,6 @@
     --tmp-color-background-caution-active: rgba(199, 90, 0, 0.18);
     --tmp-color-background-input: #f5f5f5;
     --tmp-color-background-overlay: rgba(17, 17, 17, 0.85);
-    --tmp-color-background-button-positive-default: #0e8420;
-    --tmp-color-background-button-positive-hover: #0c6d1a;
-    --tmp-color-background-button-positive-active: #0a5f17;
-    --tmp-color-background-button-negative-default: #c7162b;
-    --tmp-color-background-button-negative-hover: #b01326;
-    --tmp-color-background-button-negative-active: #a21223;
     --tmp-color-border-default: rgba(0, 0, 0, 0.2);
     --tmp-color-border-highlight: #000000;
     --tmp-color-border-high-contrast: #707070;
@@ -127,12 +46,6 @@
     --tmp-color-icon-status-shade-1: #f7f7f7;
     --tmp-color-icon-status-shade-2: #d9d9d9;
     --tmp-color-icon-status-queued: #808080;
-    --tmp-color-icon-canonical-logo: #ffffff;
-    --tmp-color-icon-button-brand: #ffffff;
-    --tmp-color-icon-button-default: #000000;
-    --tmp-color-icon-button-base: #000000;
-    --tmp-color-icon-button-positive: #ffffff;
-    --tmp-color-icon-button-negative: #ffffff;
     --tmp-color-fill-positive-hover: #0c6d1a;
     --tmp-color-fill-positive-active: #0a5f17;
     --tmp-color-fill-negative-hover: #b01326;
@@ -150,5 +63,74 @@
     --tmp-color-icon-link: var(--tmp-color-text-link-default);
     --tmp-color-fill-positive-default: var(--tmp-color-positive);
     --tmp-color-fill-negative-default: var(--tmp-color-negative);
+  }
+}
+
+
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --tmp-color-brand-default: #e95420;
+    --tmp-color-brand-hover: #da4816;
+    --tmp-color-brand-active: #cc4414;
+    --tmp-color-positive: #62a36c;
+    --tmp-color-negative: #d17b85;
+    --tmp-color-information: #5ea6ed;
+    --tmp-color-caution: #c48831;
+    --tmp-color-text-default: #ffffff;
+    --tmp-color-text-muted: rgba(255, 255, 255, 0.6);
+    --tmp-color-text-inactive: rgba(255, 255, 255, 0.75);
+    --tmp-color-text-reversed: #000000;
+    --tmp-color-text-link-default: #6699cc;
+    --tmp-color-text-link-visited: #a679d2;
+    --tmp-color-background-default: #262626;
+    --tmp-color-background-hover: #313131;
+    --tmp-color-background-active: #373737;
+    --tmp-color-background-alt: #202020;
+    --tmp-color-background-neutral-default: rgba(255, 255, 255, 0.15);
+    --tmp-color-background-neutral-hover: rgba(255, 255, 255, 0.2);
+    --tmp-color-background-neutral-active: rgba(255, 255, 255, 0.25);
+    --tmp-color-background-positive-default: rgba(10, 189, 37, 0.2);
+    --tmp-color-background-positive-hover: rgba(0, 199, 30, 0.3);
+    --tmp-color-background-positive-active: rgba(0, 199, 30, 0.36);
+    --tmp-color-background-negative-default: rgba(255, 102, 120, 0.2);
+    --tmp-color-background-negative-hover: rgba(255, 102, 120, 0.3);
+    --tmp-color-background-negative-active: rgba(255, 102, 120, 0.36);
+    --tmp-color-background-information-default: rgba(0, 137, 255, 0.2);
+    --tmp-color-background-information-hover: rgba(0, 137, 255, 0.3);
+    --tmp-color-background-information-active: rgba(0, 137, 255, 0.36);
+    --tmp-color-background-caution-default: rgba(255, 115, 0, 0.2);
+    --tmp-color-background-caution-hover: rgba(255, 143, 51, 0.3);
+    --tmp-color-background-caution-active: rgba(255, 115, 0, 0.36);
+    --tmp-color-background-input: #2f2f2f;
+    --tmp-color-background-overlay: rgba(17, 17, 17, 0.85);
+    --tmp-color-border-default: rgba(255, 255, 255, 0.2);
+    --tmp-color-border-highlight: #ffffff;
+    --tmp-color-border-high-contrast: #939393;
+    --tmp-color-border-low-contrast: rgba(255, 255, 255, 0.1);
+    --tmp-color-border-neutral: #a6a6a6;
+    --tmp-color-icon-status-shade-1: #f7f7f7;
+    --tmp-color-icon-status-shade-2: #d9d9d9;
+    --tmp-color-icon-status-queued: #808080;
+    --tmp-color-fill-positive-default: #008013;
+    --tmp-color-fill-positive-hover: #00670f;
+    --tmp-color-fill-positive-active: #00570d;
+    --tmp-color-fill-negative-default: #a11223;
+    --tmp-color-fill-negative-hover: #8a0f1e;
+    --tmp-color-fill-negative-active: #7c0e1b;
+    --tmp-color-border-positive: var(--tmp-color-positive);
+    --tmp-color-border-negative: var(--tmp-color-negative);
+    --tmp-color-border-information: var(--tmp-color-information);
+    --tmp-color-border-caution: var(--tmp-color-caution);
+    --tmp-color-icon-default: var(--tmp-color-text-default);
+    --tmp-color-icon-muted: var(--tmp-color-text-muted);
+    --tmp-color-icon-positive: var(--tmp-color-positive);
+    --tmp-color-icon-negative: var(--tmp-color-negative);
+    --tmp-color-icon-information: var(--tmp-color-information);
+    --tmp-color-icon-caution: var(--tmp-color-caution);
+    --tmp-color-icon-link: var(--tmp-color-text-link-default);
   }
 }

--- a/dist/figma/color/dark.json
+++ b/dist/figma/color/dark.json
@@ -37,11 +37,11 @@
           "$type": "color"
         },
         "muted": {
-          "$value": "rgba(255, 255, 255, 0.6)",
+          "$value": "#ffffff99",
           "$type": "color"
         },
         "inactive": {
-          "$value": "rgba(255, 255, 255, 0.75)",
+          "$value": "#ffffffbf",
           "$type": "color"
         },
         "reversed": {
@@ -78,71 +78,71 @@
         },
         "neutral": {
           "default": {
-            "$value": "rgba(255, 255, 255, 0.15)",
+            "$value": "#ffffff26",
             "$type": "color"
           },
           "hover": {
-            "$value": "rgba(255, 255, 255, 0.20)",
+            "$value": "#ffffff33",
             "$type": "color"
           },
           "active": {
-            "$value": "rgba(255, 255, 255, 0.25)",
+            "$value": "#ffffff40",
             "$type": "color"
           }
         },
         "positive": {
           "default": {
-            "$value": "rgba(10, 189, 37, 0.20)",
+            "$value": "#0abd2533",
             "$type": "color"
           },
           "hover": {
-            "$value": "rgba(0, 199, 30, 0.30)",
+            "$value": "#00c71e4d",
             "$type": "color"
           },
           "active": {
-            "$value": "rgba(0, 199, 30, 0.36)",
+            "$value": "#00c71e5c",
             "$type": "color"
           }
         },
         "negative": {
           "default": {
-            "$value": "rgba(255, 102, 120, 0.20)",
+            "$value": "#ff667833",
             "$type": "color"
           },
           "hover": {
-            "$value": "rgba(255, 102, 120, 0.30)",
+            "$value": "#ff66784d",
             "$type": "color"
           },
           "active": {
-            "$value": "rgba(255, 102, 120, 0.36)",
+            "$value": "#ff66785c",
             "$type": "color"
           }
         },
         "information": {
           "default": {
-            "$value": "rgba(0, 137, 255, 0.20)",
+            "$value": "#0089ff33",
             "$type": "color"
           },
           "hover": {
-            "$value": "rgba(0, 137, 255, 0.30)",
+            "$value": "#0089ff4d",
             "$type": "color"
           },
           "active": {
-            "$value": "rgba(0, 137, 255, 0.36)",
+            "$value": "#0089ff5c",
             "$type": "color"
           }
         },
         "caution": {
           "default": {
-            "$value": "rgba(255, 115, 0, 0.20)",
+            "$value": "#ff730033",
             "$type": "color"
           },
           "hover": {
-            "$value": "rgba(255, 143, 51, 0.30)",
+            "$value": "#ff8f334d",
             "$type": "color"
           },
           "active": {
-            "$value": "rgba(255, 115, 0, 0.36)",
+            "$value": "#ff73005c",
             "$type": "color"
           }
         },
@@ -151,13 +151,13 @@
           "$type": "color"
         },
         "overlay": {
-          "$value": "rgba(17, 17, 17, 0.85)",
+          "$value": "#111111d9",
           "$type": "color"
         }
       },
       "border": {
         "default": {
-          "$value": "rgba(255, 255, 255, 0.20)",
+          "$value": "#ffffff33",
           "$type": "color"
         },
         "highlight": {
@@ -169,7 +169,7 @@
           "$type": "color"
         },
         "low-contrast": {
-          "$value": "rgba(255, 255, 255, 0.10)",
+          "$value": "#ffffff1a",
           "$type": "color"
         },
         "neutral": {

--- a/dist/figma/color/dark.json
+++ b/dist/figma/color/dark.json
@@ -193,49 +193,49 @@
           "$type": "color"
         },
         "positive": {
-          "$value": "#62A36C",
+          "$value": "{tmp.color.positive}",
           "$type": "color"
         },
         "negative": {
-          "$value": "#D17B85",
+          "$value": "{tmp.color.negative}",
           "$type": "color"
         },
         "information": {
-          "$value": "#5EA6ED",
+          "$value": "{tmp.color.information}",
           "$type": "color"
         },
         "caution": {
-          "$value": "#C48831",
+          "$value": "{tmp.color.caution}",
           "$type": "color"
         }
       },
       "icon": {
         "default": {
-          "$value": "#ffffff",
+          "$value": "{tmp.color.text.default}",
           "$type": "color"
         },
         "muted": {
-          "$value": "rgba(255, 255, 255, 0.6)",
+          "$value": "{tmp.color.text.muted}",
           "$type": "color"
         },
         "positive": {
-          "$value": "#62A36C",
+          "$value": "{tmp.color.positive}",
           "$type": "color"
         },
         "negative": {
-          "$value": "#D17B85",
+          "$value": "{tmp.color.negative}",
           "$type": "color"
         },
         "information": {
-          "$value": "#5EA6ED",
+          "$value": "{tmp.color.information}",
           "$type": "color"
         },
         "caution": {
-          "$value": "#C48831",
+          "$value": "{tmp.color.caution}",
           "$type": "color"
         },
         "link": {
-          "$value": "#6699cc",
+          "$value": "{tmp.color.text.link.default}",
           "$type": "color"
         },
         "status": {

--- a/dist/figma/color/dark.json
+++ b/dist/figma/color/dark.json
@@ -1,6 +1,20 @@
 {
   "tmp": {
     "color": {
+      "brand": {
+        "default": {
+          "$value": "#e95420",
+          "$type": "color"
+        },
+        "hover": {
+          "$value": "#da4816",
+          "$type": "color"
+        },
+        "active": {
+          "$value": "#cc4414",
+          "$type": "color"
+        }
+      },
       "positive": {
         "$value": "#62A36C",
         "$type": "color"
@@ -139,36 +153,6 @@
         "overlay": {
           "$value": "rgba(17, 17, 17, 0.85)",
           "$type": "color"
-        },
-        "button": {
-          "positive": {
-            "default": {
-              "$value": "#008013",
-              "$type": "color"
-            },
-            "hover": {
-              "$value": "#00670f",
-              "$type": "color"
-            },
-            "active": {
-              "$value": "#00570d",
-              "$type": "color"
-            }
-          },
-          "negative": {
-            "default": {
-              "$value": "#a11223",
-              "$type": "color"
-            },
-            "hover": {
-              "$value": "#8a0f1e",
-              "$type": "color"
-            },
-            "active": {
-              "$value": "#7c0e1b",
-              "$type": "color"
-            }
-          }
         }
       },
       "border": {
@@ -249,32 +233,6 @@
           },
           "queued": {
             "$value": "#808080",
-            "$type": "color"
-          }
-        },
-        "canonical-logo": {
-          "$value": "#ffffff",
-          "$type": "color"
-        },
-        "button": {
-          "brand": {
-            "$value": "#ffffff",
-            "$type": "color"
-          },
-          "default": {
-            "$value": "#000000",
-            "$type": "color"
-          },
-          "base": {
-            "$value": "#000000",
-            "$type": "color"
-          },
-          "positive": {
-            "$value": "#ffffff",
-            "$type": "color"
-          },
-          "negative": {
-            "$value": "#ffffff",
             "$type": "color"
           }
         }

--- a/dist/figma/color/light.json
+++ b/dist/figma/color/light.json
@@ -37,11 +37,11 @@
           "$type": "color"
         },
         "muted": {
-          "$value": "rgba(0, 0, 0, 0.60)",
+          "$value": "#00000099",
           "$type": "color"
         },
         "inactive": {
-          "$value": "rgba(0, 0, 0, 0.75)",
+          "$value": "#000000bf",
           "$type": "color"
         },
         "reversed": {
@@ -92,57 +92,57 @@
         },
         "positive": {
           "default": {
-            "$value": "rgba(10, 189, 37, 0.10)",
+            "$value": "#0abd251a",
             "$type": "color"
           },
           "hover": {
-            "$value": "rgba(0, 199, 30, 0.15)",
+            "$value": "#00c71e26",
             "$type": "color"
           },
           "active": {
-            "$value": "rgba(0, 199, 30, 0.18)",
+            "$value": "#00c71e2e",
             "$type": "color"
           }
         },
         "negative": {
           "default": {
-            "$value": "rgba(199, 0, 20, 0.10)",
+            "$value": "#c700141a",
             "$type": "color"
           },
           "hover": {
-            "$value": "rgba(199, 0, 20, 0.15)",
+            "$value": "#c7001426",
             "$type": "color"
           },
           "active": {
-            "$value": "rgba(199, 0, 20, 0.18)",
+            "$value": "#c700142e",
             "$type": "color"
           }
         },
         "information": {
           "default": {
-            "$value": "rgba(0, 99, 199, 0.10)",
+            "$value": "#0063c71a",
             "$type": "color"
           },
           "hover": {
-            "$value": "rgba(0, 99, 199, 0.15)",
+            "$value": "#0063c726",
             "$type": "color"
           },
           "active": {
-            "$value": "rgba(0, 99, 199, 0.18)",
+            "$value": "#0063c72e",
             "$type": "color"
           }
         },
         "caution": {
           "default": {
-            "$value": "rgba(199, 90, 0, 0.10)",
+            "$value": "#c75a001a",
             "$type": "color"
           },
           "hover": {
-            "$value": "rgba(199, 90, 0, 0.15)",
+            "$value": "#c75a0026",
             "$type": "color"
           },
           "active": {
-            "$value": "rgba(199, 90, 0, 0.18)",
+            "$value": "#c75a002e",
             "$type": "color"
           }
         },
@@ -151,13 +151,13 @@
           "$type": "color"
         },
         "overlay": {
-          "$value": "rgba(17, 17, 17, 0.85)",
+          "$value": "#111111d9",
           "$type": "color"
         }
       },
       "border": {
         "default": {
-          "$value": "rgba(0, 0, 0, 0.20)",
+          "$value": "#00000033",
           "$type": "color"
         },
         "highlight": {
@@ -169,11 +169,11 @@
           "$type": "color"
         },
         "low-contrast": {
-          "$value": "rgba(0, 0, 0, 0.10)",
+          "$value": "#0000001a",
           "$type": "color"
         },
         "neutral": {
-          "$value": "rgba(0, 0, 0, 0.56)",
+          "$value": "#0000008f",
           "$type": "color"
         },
         "positive": {

--- a/dist/figma/color/light.json
+++ b/dist/figma/color/light.json
@@ -193,49 +193,49 @@
           "$type": "color"
         },
         "positive": {
-          "$value": "#0E8420",
+          "$value": "{tmp.color.positive}",
           "$type": "color"
         },
         "negative": {
-          "$value": "#C7162B",
+          "$value": "{tmp.color.negative}",
           "$type": "color"
         },
         "information": {
-          "$value": "#24598F",
+          "$value": "{tmp.color.information}",
           "$type": "color"
         },
         "caution": {
-          "$value": "#CC7900",
+          "$value": "{tmp.color.caution}",
           "$type": "color"
         }
       },
       "icon": {
         "default": {
-          "$value": "#000000",
+          "$value": "{tmp.color.text.default}",
           "$type": "color"
         },
         "muted": {
-          "$value": "rgba(0, 0, 0, 0.60)",
+          "$value": "{tmp.color.text.muted}",
           "$type": "color"
         },
         "positive": {
-          "$value": "#0E8420",
+          "$value": "{tmp.color.positive}",
           "$type": "color"
         },
         "negative": {
-          "$value": "#C7162B",
+          "$value": "{tmp.color.negative}",
           "$type": "color"
         },
         "information": {
-          "$value": "#24598F",
+          "$value": "{tmp.color.information}",
           "$type": "color"
         },
         "caution": {
-          "$value": "#CC7900",
+          "$value": "{tmp.color.caution}",
           "$type": "color"
         },
         "link": {
-          "$value": "#0066cc",
+          "$value": "{tmp.color.text.link.default}",
           "$type": "color"
         },
         "status": {
@@ -282,7 +282,7 @@
       "fill": {
         "positive": {
           "default": {
-            "$value": "#0E8420",
+            "$value": "{tmp.color.positive}",
             "$type": "color"
           },
           "hover": {
@@ -296,7 +296,7 @@
         },
         "negative": {
           "default": {
-            "$value": "#C7162B",
+            "$value": "{tmp.color.negative}",
             "$type": "color"
           },
           "hover": {

--- a/dist/figma/color/light.json
+++ b/dist/figma/color/light.json
@@ -1,6 +1,20 @@
 {
   "tmp": {
     "color": {
+      "brand": {
+        "default": {
+          "$value": "#e95420",
+          "$type": "color"
+        },
+        "hover": {
+          "$value": "#da4816",
+          "$type": "color"
+        },
+        "active": {
+          "$value": "#cc4414",
+          "$type": "color"
+        }
+      },
       "positive": {
         "$value": "#0E8420",
         "$type": "color"
@@ -139,36 +153,6 @@
         "overlay": {
           "$value": "rgba(17, 17, 17, 0.85)",
           "$type": "color"
-        },
-        "button": {
-          "positive": {
-            "default": {
-              "$value": "#0e8420",
-              "$type": "color"
-            },
-            "hover": {
-              "$value": "#0c6d1a",
-              "$type": "color"
-            },
-            "active": {
-              "$value": "#0a5f17",
-              "$type": "color"
-            }
-          },
-          "negative": {
-            "default": {
-              "$value": "#c7162b",
-              "$type": "color"
-            },
-            "hover": {
-              "$value": "#b01326",
-              "$type": "color"
-            },
-            "active": {
-              "$value": "#a21223",
-              "$type": "color"
-            }
-          }
         }
       },
       "border": {
@@ -249,32 +233,6 @@
           },
           "queued": {
             "$value": "#808080",
-            "$type": "color"
-          }
-        },
-        "canonical-logo": {
-          "$value": "#ffffff",
-          "$type": "color"
-        },
-        "button": {
-          "brand": {
-            "$value": "#ffffff",
-            "$type": "color"
-          },
-          "default": {
-            "$value": "#000000",
-            "$type": "color"
-          },
-          "base": {
-            "$value": "#000000",
-            "$type": "color"
-          },
-          "positive": {
-            "$value": "#ffffff",
-            "$type": "color"
-          },
-          "negative": {
-            "$value": "#ffffff",
             "$type": "color"
           }
         }

--- a/dist/figma/typography/extraWide.json
+++ b/dist/figma/typography/extraWide.json
@@ -4,64 +4,28 @@
       "paragraph": {
         "xs": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "12px",
-            "fontWeight": 400,
-            "lineHeight": "18px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.xs}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.xs}"
           },
           "$type": "typography"
         },
         "s": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "14px",
-            "fontWeight": 400,
-            "lineHeight": "21px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.s}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.s}"
           },
           "$type": "typography"
         },
         "default": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "16px",
-            "fontWeight": 400,
-            "lineHeight": "24px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.m}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.m}"
           },
           "$type": "typography"
         }
@@ -69,136 +33,67 @@
       "code": {
         "xs": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "12px",
-            "fontWeight": 400,
-            "lineHeight": "18px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.xs}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.xs}"
           },
           "$type": "typography"
         },
         "s": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "14px",
-            "fontWeight": 400,
-            "lineHeight": "21px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.s}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.s}"
           },
           "$type": "typography"
         },
         "default": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "16px",
-            "fontWeight": 400,
-            "lineHeight": "24px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.m}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.m}"
           },
           "$type": "typography"
         }
       },
       "h3": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "28px",
-          "fontWeight": 450,
-          "lineHeight": "32px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.xl}",
+          "fontWeight": "{tmp.typography.weight.medium}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h4": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "28px",
-          "fontWeight": 200,
-          "lineHeight": "32px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.xl}",
+          "fontWeight": "{tmp.typography.weight.thin}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h5": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "24px",
-          "fontWeight": 450,
-          "lineHeight": "32px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.l}",
+          "fontWeight": "{tmp.typography.weight.medium}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h6": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "24px",
-          "fontWeight": 300,
-          "lineHeight": "32px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.l}",
+          "fontWeight": "{tmp.typography.weight.light}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "weight": {
         "extraThin": {

--- a/dist/figma/typography/medium.json
+++ b/dist/figma/typography/medium.json
@@ -4,64 +4,28 @@
       "paragraph": {
         "xs": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "lineHeight": "15px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.xs}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.xs}"
           },
           "$type": "typography"
         },
         "s": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "12px",
-            "fontWeight": 400,
-            "lineHeight": "18px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.s}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.s}"
           },
           "$type": "typography"
         },
         "default": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "14px",
-            "fontWeight": 400,
-            "lineHeight": "21px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.m}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.m}"
           },
           "$type": "typography"
         }
@@ -69,136 +33,67 @@
       "code": {
         "xs": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "lineHeight": "15px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.xs}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.xs}"
           },
           "$type": "typography"
         },
         "s": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "12px",
-            "fontWeight": 400,
-            "lineHeight": "18px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.s}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.s}"
           },
           "$type": "typography"
         },
         "default": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "14px",
-            "fontWeight": 400,
-            "lineHeight": "21px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.m}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.m}"
           },
           "$type": "typography"
         }
       },
       "h3": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "24px",
-          "fontWeight": 450,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.xl}",
+          "fontWeight": "{tmp.typography.weight.medium}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h4": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "24px",
-          "fontWeight": 200,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.xl}",
+          "fontWeight": "{tmp.typography.weight.thin}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h5": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "21px",
-          "fontWeight": 450,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.l}",
+          "fontWeight": "{tmp.typography.weight.medium}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h6": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "21px",
-          "fontWeight": 300,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.l}",
+          "fontWeight": "{tmp.typography.weight.light}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "weight": {
         "extraThin": {

--- a/dist/figma/typography/narrow.json
+++ b/dist/figma/typography/narrow.json
@@ -4,64 +4,28 @@
       "paragraph": {
         "xs": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "lineHeight": "15px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.xs}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.xs}"
           },
           "$type": "typography"
         },
         "s": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "12px",
-            "fontWeight": 400,
-            "lineHeight": "18px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.s}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.s}"
           },
           "$type": "typography"
         },
         "default": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "14px",
-            "fontWeight": 400,
-            "lineHeight": "21px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.m}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.m}"
           },
           "$type": "typography"
         }
@@ -69,136 +33,67 @@
       "code": {
         "xs": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "lineHeight": "15px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.xs}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.xs}"
           },
           "$type": "typography"
         },
         "s": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "12px",
-            "fontWeight": 400,
-            "lineHeight": "18px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.s}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.s}"
           },
           "$type": "typography"
         },
         "default": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "14px",
-            "fontWeight": 400,
-            "lineHeight": "21px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.m}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.m}"
           },
           "$type": "typography"
         }
       },
       "h3": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "24px",
-          "fontWeight": 450,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.xl}",
+          "fontWeight": "{tmp.typography.weight.medium}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h4": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "24px",
-          "fontWeight": 200,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.xl}",
+          "fontWeight": "{tmp.typography.weight.thin}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h5": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "21px",
-          "fontWeight": 450,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.l}",
+          "fontWeight": "{tmp.typography.weight.medium}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h6": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "21px",
-          "fontWeight": 300,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.l}",
+          "fontWeight": "{tmp.typography.weight.light}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "weight": {
         "extraThin": {

--- a/dist/figma/typography/wide.json
+++ b/dist/figma/typography/wide.json
@@ -4,64 +4,28 @@
       "paragraph": {
         "xs": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "lineHeight": "15px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.xs}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.xs}"
           },
           "$type": "typography"
         },
         "s": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "12px",
-            "fontWeight": 400,
-            "lineHeight": "18px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.s}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.s}"
           },
           "$type": "typography"
         },
         "default": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans",
-              "Ubuntu",
-              "-apple-system",
-              "Segoe UI",
-              "Roboto",
-              "Oxygen",
-              "Cantarell",
-              "Fira Sans",
-              "Droid Sans",
-              "Helvetica Neue",
-              "sans-serif"
-            ],
-            "fontSize": "14px",
-            "fontWeight": 400,
-            "lineHeight": "21px"
+            "fontFamily": "{tmp.typography.fontFamily.default}",
+            "fontSize": "{tmp.typography.fontSize.m}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.m}"
           },
           "$type": "typography"
         }
@@ -69,136 +33,67 @@
       "code": {
         "xs": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "10px",
-            "fontWeight": 400,
-            "lineHeight": "15px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.xs}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.xs}"
           },
           "$type": "typography"
         },
         "s": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "12px",
-            "fontWeight": 400,
-            "lineHeight": "18px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.s}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.s}"
           },
           "$type": "typography"
         },
         "default": {
           "$value": {
-            "fontFamily": [
-              "Ubuntu Sans Mono",
-              "Ubuntu Mono",
-              "Consolas",
-              "Monaco",
-              "Courier",
-              "monospace"
-            ],
-            "fontSize": "14px",
-            "fontWeight": 400,
-            "lineHeight": "21px"
+            "fontFamily": "{tmp.typography.fontFamily.mono}",
+            "fontSize": "{tmp.typography.fontSize.m}",
+            "fontWeight": "{tmp.typography.weight.regular}",
+            "lineHeight": "{tmp.typography.lineHeight.m}"
           },
           "$type": "typography"
         }
       },
       "h3": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "24px",
-          "fontWeight": 450,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.xl}",
+          "fontWeight": "{tmp.typography.weight.medium}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h4": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "24px",
-          "fontWeight": 200,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.xl}",
+          "fontWeight": "{tmp.typography.weight.thin}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h5": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "21px",
-          "fontWeight": 450,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.l}",
+          "fontWeight": "{tmp.typography.weight.medium}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "h6": {
-        "$type": "typography",
         "$value": {
-          "fontFamily": [
-            "Ubuntu Sans",
-            "Ubuntu",
-            "-apple-system",
-            "Segoe UI",
-            "Roboto",
-            "Oxygen",
-            "Cantarell",
-            "Fira Sans",
-            "Droid Sans",
-            "Helvetica Neue",
-            "sans-serif"
-          ],
-          "fontSize": "21px",
-          "fontWeight": 300,
-          "lineHeight": "28px"
-        }
+          "fontFamily": "{tmp.typography.fontFamily.default}",
+          "fontSize": "{tmp.typography.fontSize.l}",
+          "fontWeight": "{tmp.typography.weight.light}",
+          "lineHeight": "{tmp.typography.lineHeight.l}"
+        },
+        "$type": "typography"
       },
       "weight": {
         "extraThin": {

--- a/src/build/color.ts
+++ b/src/build/color.ts
@@ -1,3 +1,4 @@
+import type { Category } from "./utils/consts.js";
 import {
   type ModeToCSSCompose,
   buildCSSComposedMode,
@@ -5,7 +6,7 @@ import {
   readModes,
 } from "./utils/modes.js";
 
-const category = "color";
+const category: Category = "color";
 const simpleModes = await readModes(category);
 
 await buildSimpleModes(category, simpleModes);

--- a/src/build/dimension.ts
+++ b/src/build/dimension.ts
@@ -1,4 +1,4 @@
-import { mediaQueryMinWidths } from "./utils/consts.js";
+import { type Category, mediaQueryMinWidths } from "./utils/consts.js";
 import { isCommon } from "./utils/filters.js";
 import {
   type ModeToCSSCompose,
@@ -7,7 +7,7 @@ import {
   readModes,
 } from "./utils/modes.js";
 
-const category = "dimension";
+const category: Category = "dimension";
 const simpleModes = await readModes(category);
 
 await buildSimpleModes(category, simpleModes);
@@ -18,11 +18,9 @@ await buildSimpleModes(category, simpleModes);
   const configs: Array<Omit<ModeToCSSCompose, "path">> = [
     {
       modeName: "narrow",
-      order: 1,
     },
     {
       modeName: "medium",
-      order: 2,
       filesOptions: {
         rules: [
           {
@@ -34,7 +32,6 @@ await buildSimpleModes(category, simpleModes);
     },
     {
       modeName: "wide",
-      order: 3,
       filesOptions: {
         rules: [
           {
@@ -46,7 +43,6 @@ await buildSimpleModes(category, simpleModes);
     },
     {
       modeName: "extraWide",
-      order: 4,
       filesOptions: {
         rules: [
           {

--- a/src/build/typography.ts
+++ b/src/build/typography.ts
@@ -1,5 +1,4 @@
-import { TransformedToken } from "style-dictionary";
-import { mediaQueryMinWidths } from "./utils/consts.js";
+import { type Category, mediaQueryMinWidths } from "./utils/consts.js";
 import { isCommon } from "./utils/filters.js";
 import {
   type ModeToCSSCompose,
@@ -8,7 +7,7 @@ import {
   readModes,
 } from "./utils/modes.js";
 
-const category = "typography";
+const category: Category = "typography";
 const simpleModes = await readModes(category);
 
 await buildSimpleModes(category, simpleModes);
@@ -19,11 +18,9 @@ await buildSimpleModes(category, simpleModes);
   const configs: Array<Omit<ModeToCSSCompose, "path">> = [
     {
       modeName: "narrow",
-      order: 1,
     },
     {
       modeName: "medium",
-      order: 2,
       filesOptions: {
         rules: [
           {
@@ -35,7 +32,6 @@ await buildSimpleModes(category, simpleModes);
     },
     {
       modeName: "wide",
-      order: 3,
       filesOptions: {
         rules: [
           {
@@ -47,7 +43,6 @@ await buildSimpleModes(category, simpleModes);
     },
     {
       modeName: "extraWide",
-      order: 4,
       filesOptions: {
         rules: [
           {

--- a/src/build/utils/consts.ts
+++ b/src/build/utils/consts.ts
@@ -7,4 +7,14 @@ export enum mediaQueryMinWidths {
   xlarge = "1681px",
 }
 
-export const commonModesComponentName = "+common.json";
+export const commonModesTokensName = "+common.json";
+
+export const baseTokensPath = "src/tokens";
+export const baseBuildPath = "dist";
+export const categories = ["color", "typography", "dimension"] as const;
+export const tokenTypes = ["primitives", "semantic"] as const;
+export const platforms = ["css", "figma"] as const;
+
+export type Category = (typeof categories)[number];
+export type TokenType = (typeof tokenTypes)[number];
+export type Platform = (typeof platforms)[number];

--- a/src/build/utils/filters.ts
+++ b/src/build/utils/filters.ts
@@ -1,10 +1,14 @@
 import type { TransformedToken } from "style-dictionary";
-import { commonModesComponentName } from "./consts.js";
+import { commonModesTokensName } from "./consts.js";
+
+export function isPrimitive(token: TransformedToken) {
+  return token.filePath.includes("primitive");
+}
 
 export function isSemantic(token: TransformedToken) {
   return token.filePath.includes("semantic");
 }
 
 export function isCommon(token: TransformedToken) {
-  return token.filePath.endsWith(commonModesComponentName);
+  return token.filePath.endsWith(commonModesTokensName);
 }

--- a/src/build/utils/modes.ts
+++ b/src/build/utils/modes.ts
@@ -2,7 +2,7 @@ import { readdir, rm } from "node:fs/promises";
 import type { PlatformConfig, TransformedToken } from "style-dictionary";
 import { StyleDictionary } from "style-dictionary-utils";
 import { formats } from "style-dictionary/enums";
-import { baseConfig, logOptions } from "./baseConfig.js";
+import { baseConfig, customFormats, logOptions } from "./baseConfig.js";
 import { commonModesComponentName } from "./consts.js";
 import { isSemantic } from "./filters.js";
 
@@ -70,7 +70,7 @@ export async function buildSimpleModes(category: string, modes: Mode[]) {
             files: [
               {
                 destination: `${modeName}.json`,
-                format: formats.json,
+                format: customFormats.figma,
                 filter: isSemantic,
               },
             ],

--- a/src/build/utils/path.ts
+++ b/src/build/utils/path.ts
@@ -1,0 +1,18 @@
+import {
+  type Category,
+  type Platform,
+  type TokenType,
+  baseBuildPath,
+  baseTokensPath,
+} from "./consts.js";
+
+export function getBaseCategoryPath(
+  category: Category,
+  tokensType: TokenType = "semantic",
+): string {
+  return `${baseTokensPath}/${tokensType}/${category}`;
+}
+
+export function getBuildPath(platform: Platform, category: Category): string {
+  return `${baseBuildPath}/${platform}/${category}`;
+}

--- a/src/tokens/semantic/color/dark.json
+++ b/src/tokens/semantic/color/dark.json
@@ -30,10 +30,10 @@
           "$value": "#ffffff"
         },
         "muted": {
-          "$value": "rgba(255, 255, 255, 0.6)"
+          "$value": "#ffffff99"
         },
         "inactive": {
-          "$value": "rgba(255, 255, 255, 0.75)"
+          "$value": "#ffffffbf"
         },
         "reversed": {
           "$value": "#000000"
@@ -62,69 +62,69 @@
         },
         "neutral": {
           "default": {
-            "$value": "rgba(255, 255, 255, 0.15)"
+            "$value": "#ffffff26"
           },
           "hover": {
-            "$value": "rgba(255, 255, 255, 0.20)"
+            "$value": "#ffffff33"
           },
           "active": {
-            "$value": "rgba(255, 255, 255, 0.25)"
+            "$value": "#ffffff40"
           }
         },
         "positive": {
           "default": {
-            "$value": "rgba(10, 189, 37, 0.20)"
+            "$value": "#0abd2533"
           },
           "hover": {
-            "$value": "rgba(0, 199, 30, 0.30)"
+            "$value": "#00c71e4d"
           },
           "active": {
-            "$value": "rgba(0, 199, 30, 0.36)"
+            "$value": "#00c71e5c"
           }
         },
         "negative": {
           "default": {
-            "$value": "rgba(255, 102, 120, 0.20)"
+            "$value": "#ff667833"
           },
           "hover": {
-            "$value": "rgba(255, 102, 120, 0.30)"
+            "$value": "#ff66784d"
           },
           "active": {
-            "$value": "rgba(255, 102, 120, 0.36)"
+            "$value": "#ff66785c"
           }
         },
         "information": {
           "default": {
-            "$value": "rgba(0, 137, 255, 0.20)"
+            "$value": "#0089ff33"
           },
           "hover": {
-            "$value": "rgba(0, 137, 255, 0.30)"
+            "$value": "#0089ff4d"
           },
           "active": {
-            "$value": "rgba(0, 137, 255, 0.36)"
+            "$value": "#0089ff5c"
           }
         },
         "caution": {
           "default": {
-            "$value": "rgba(255, 115, 0, 0.20)"
+            "$value": "#ff730033"
           },
           "hover": {
-            "$value": "rgba(255, 143, 51, 0.30)"
+            "$value": "#ff8f334d"
           },
           "active": {
-            "$value": "rgba(255, 115, 0, 0.36)"
+            "$value": "#ff73005c"
           }
         },
         "input": {
           "$value": "#2f2f2f"
         },
         "overlay": {
-          "$value": "rgba(17, 17, 17, 0.85)"
+          "$value": "#111111d9"
         }
       },
       "border": {
         "default": {
-          "$value": "rgba(255, 255, 255, 0.20)"
+          "$value": "#ffffff33"
         },
         "highlight": {
           "$value": "#ffffff"
@@ -133,7 +133,7 @@
           "$value": "#939393"
         },
         "low-contrast": {
-          "$value": "rgba(255, 255, 255, 0.10)"
+          "$value": "#ffffff1a"
         },
         "neutral": {
           "$value": "#a6a6a6"

--- a/src/tokens/semantic/color/dark.json
+++ b/src/tokens/semantic/color/dark.json
@@ -2,6 +2,17 @@
   "tmp": {
     "color": {
       "$type": "color",
+      "brand": {
+        "default": {
+          "$value": "#e95420"
+        },
+        "hover": {
+          "$value": "#da4816"
+        },
+        "active": {
+          "$value": "#cc4414"
+        }
+      },
       "positive": {
         "$value": "#62A36C"
       },
@@ -109,30 +120,6 @@
         },
         "overlay": {
           "$value": "rgba(17, 17, 17, 0.85)"
-        },
-        "button": {
-          "positive": {
-            "default": {
-              "$value": "#008013"
-            },
-            "hover": {
-              "$value": "#00670f"
-            },
-            "active": {
-              "$value": "#00570d"
-            }
-          },
-          "negative": {
-            "default": {
-              "$value": "#a11223"
-            },
-            "hover": {
-              "$value": "#8a0f1e"
-            },
-            "active": {
-              "$value": "#7c0e1b"
-            }
-          }
         }
       },
       "border": {
@@ -195,26 +182,6 @@
           },
           "queued": {
             "$value": "#808080"
-          }
-        },
-        "canonical-logo": {
-          "$value": "#ffffff"
-        },
-        "button": {
-          "brand": {
-            "$value": "#ffffff"
-          },
-          "default": {
-            "$value": "#000000"
-          },
-          "base": {
-            "$value": "#000000"
-          },
-          "positive": {
-            "$value": "#ffffff"
-          },
-          "negative": {
-            "$value": "#ffffff"
           }
         }
       },

--- a/src/tokens/semantic/color/light.json
+++ b/src/tokens/semantic/color/light.json
@@ -30,10 +30,10 @@
           "$value": "#000000"
         },
         "muted": {
-          "$value": "rgba(0, 0, 0, 0.60)"
+          "$value": "#00000099"
         },
         "inactive": {
-          "$value": "rgba(0, 0, 0, 0.75)"
+          "$value": "#000000bf"
         },
         "reversed": {
           "$value": "#ffffff"
@@ -73,58 +73,58 @@
         },
         "positive": {
           "default": {
-            "$value": "rgba(10, 189, 37, 0.10)"
+            "$value": "#0abd251a"
           },
           "hover": {
-            "$value": "rgba(0, 199, 30, 0.15)"
+            "$value": "#00c71e26"
           },
           "active": {
-            "$value": "rgba(0, 199, 30, 0.18)"
+            "$value": "#00c71e2e"
           }
         },
         "negative": {
           "default": {
-            "$value": "rgba(199, 0, 20, 0.10)"
+            "$value": "#c700141a"
           },
           "hover": {
-            "$value": "rgba(199, 0, 20, 0.15)"
+            "$value": "#c7001426"
           },
           "active": {
-            "$value": "rgba(199, 0, 20, 0.18)"
+            "$value": "#c700142e"
           }
         },
         "information": {
           "default": {
-            "$value": "rgba(0, 99, 199, 0.10)"
+            "$value": "#0063c71a"
           },
           "hover": {
-            "$value": "rgba(0, 99, 199, 0.15)"
+            "$value": "#0063c726"
           },
           "active": {
-            "$value": "rgba(0, 99, 199, 0.18)"
+            "$value": "#0063c72e"
           }
         },
         "caution": {
           "default": {
-            "$value": "rgba(199, 90, 0, 0.10)"
+            "$value": "#c75a001a"
           },
           "hover": {
-            "$value": "rgba(199, 90, 0, 0.15)"
+            "$value": "#c75a0026"
           },
           "active": {
-            "$value": "rgba(199, 90, 0, 0.18)"
+            "$value": "#c75a002e"
           }
         },
         "input": {
           "$value": "#f5f5f5"
         },
         "overlay": {
-          "$value": "rgba(17, 17, 17, 0.85)"
+          "$value": "#111111d9"
         }
       },
       "border": {
         "default": {
-          "$value": "rgba(0, 0, 0, 0.20)"
+          "$value": "#00000033"
         },
         "highlight": {
           "$value": "#000000"
@@ -133,10 +133,10 @@
           "$value": "#707070"
         },
         "low-contrast": {
-          "$value": "rgba(0, 0, 0, 0.10)"
+          "$value": "#0000001a"
         },
         "neutral": {
-          "$value": "rgba(0, 0, 0, 0.56)"
+          "$value": "#0000008f"
         },
         "positive": {
           "$value": "{tmp.color.positive}"

--- a/src/tokens/semantic/color/light.json
+++ b/src/tokens/semantic/color/light.json
@@ -2,6 +2,17 @@
   "tmp": {
     "color": {
       "$type": "color",
+      "brand": {
+        "default": {
+          "$value": "#e95420"
+        },
+        "hover": {
+          "$value": "#da4816"
+        },
+        "active": {
+          "$value": "#cc4414"
+        }
+      },
       "positive": {
         "$value": "#0E8420"
       },
@@ -109,30 +120,6 @@
         },
         "overlay": {
           "$value": "rgba(17, 17, 17, 0.85)"
-        },
-        "button": {
-          "positive": {
-            "default": {
-              "$value": "#0e8420"
-            },
-            "hover": {
-              "$value": "#0c6d1a"
-            },
-            "active": {
-              "$value": "#0a5f17"
-            }
-          },
-          "negative": {
-            "default": {
-              "$value": "#c7162b"
-            },
-            "hover": {
-              "$value": "#b01326"
-            },
-            "active": {
-              "$value": "#a21223"
-            }
-          }
         }
       },
       "border": {
@@ -195,26 +182,6 @@
           },
           "queued": {
             "$value": "#808080"
-          }
-        },
-        "canonical-logo": {
-          "$value": "#ffffff"
-        },
-        "button": {
-          "brand": {
-            "$value": "#ffffff"
-          },
-          "default": {
-            "$value": "#000000"
-          },
-          "base": {
-            "$value": "#000000"
-          },
-          "positive": {
-            "$value": "#ffffff"
-          },
-          "negative": {
-            "$value": "#ffffff"
           }
         }
       },


### PR DESCRIPTION
- More reused constants were moved to consts.ts.
- Type safety was improved by changing some string occurrences to string literals.
- Modes composition ordering was simplified – order no longer needs to be supplied, and modes are composed in the order they are defined.
- RGBA color definitions were changed to hex.

Prerequisite PR: #15.